### PR TITLE
validate active record validation error messages, add show update met…

### DIFF
--- a/app/controllers/api/v1/admins/registrations_controller.rb
+++ b/app/controllers/api/v1/admins/registrations_controller.rb
@@ -14,7 +14,7 @@ module Api
       end
 
       def register_failed
-        render json: { message: 'Signed up failure.' }, status: :unauthorized
+        render json: { message: resource.errors.full_messages }, status: :unauthorized
       end
     end
   end

--- a/app/controllers/api/v1/admins_controller.rb
+++ b/app/controllers/api/v1/admins_controller.rb
@@ -1,0 +1,30 @@
+class Api::V1::AdminsController < ApplicationController
+  before_action :set_admin, only: %i[show update]
+  before_action :authenticate_admin!
+
+  def index; end
+
+  def show
+    render json: @admin
+  end
+
+  def update
+    if @admin.update(admin_params)
+      # Sign in the user by passing validation in case their password changed
+      bypass_sign_in(@admin)
+      render json: { status: 201, message: 'Admin account successfully updated.', data: @admin }, status: :created
+    else
+      render json: { status: 400, data: { message: @admin.errors } }, status: :bad_request
+    end
+  end
+
+  private
+
+  def set_admin
+    @admin = Admin.find(params[:id])
+  end
+
+  def admin_params
+    params.require(:admin).permit(:email, :password)
+  end
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -6,6 +6,6 @@ class Admin < ApplicationRecord
          :registerable,
          jwt_revocation_strategy: JwtDenylist
 
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: true, format: { with: Devise.email_regexp }
   validates :password, presence: true, length: { minimum: 6 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,6 @@ class User < ApplicationRecord
   has_many :feedbacks, dependent: :destroy
 
   validates :fullname, presence: true
-  validates :email, presence: true
+  validates :email, presence: true, format: { with: Devise.email_regexp }
   validates :phone, presence: true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,3 +31,4 @@
 
 en:
   hello: "Hello world"
+  email: "You entered invalid email."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,14 @@ Rails.application.routes.draw do
   },
   defaults: {format: :json}
 
-
   namespace :api do
     namespace :v1 do
       resources :users do
         resources :feedbacks
       end
+      get '/admin/:id', to: 'admins#show'
+      put '/admin/:id', to: 'admins#update'
+      
     end
   end
 end


### PR DESCRIPTION
## Summary
- Validate error messages responses 
- Add admin controller for show and update

## Screenshots
#### access admin without session
![access admin without session](https://user-images.githubusercontent.com/88585596/160274953-7afa2029-9521-4b0f-be06-18658950580c.JPG)

#### invalid email error for admin
![invalid email error for admin](https://user-images.githubusercontent.com/88585596/160274965-6acda3a3-fea1-41e7-b6e2-7feacb90bdbd.JPG)

####  uniqueness error message for admin
![uniqueness error message for admin](https://user-images.githubusercontent.com/88585596/160274968-b4b7a515-86d3-4fda-926c-9dd347e72dac.JPG)

#### access admin info with session
![access admin info with session](https://user-images.githubusercontent.com/88585596/160274974-e627f350-368f-4bdd-8ace-22966f17874b.JPG)

#### updating admin detail
![updating admin detail](https://user-images.githubusercontent.com/88585596/160274985-5bb00188-4334-404f-8709-3a3e595930b0.JPG)



## References
https://github.com/heartcombo/devise/wiki/How-To:-Allow-users-to-edit-their-password